### PR TITLE
 Fix when there is no evidence on submission

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,8 +6,13 @@ export type AppConfig = {
 
 export type ServerConfig = {
   port: number;
+  sandboxConfig: SandboxConfig;
+};
+
+export type SandboxConfig = {
   mockChallengeInfo: boolean;
-  postMessageToTelegramOnSanbox: boolean;
+  postMessageToTelegram: boolean;
+  SubmissionIdToFetch: string;
 };
 
 export type InfuraConfig = {
@@ -23,9 +28,14 @@ export const appConfigFromEnvironment = (): Promise<AppConfig> => {
   const config: AppConfig = {
     serverConfig: {
       port: parseInt(process.env["PORT"] ?? "5000"),
-      mockChallengeInfo: process.env["MOCK_CHALLENGE_INFO"] === "true",
-      postMessageToTelegramOnSanbox:
-        process.env["POST_MESSAGE_TO_TELEGRAM_ON_SANDBOX"] === "true",
+      sandboxConfig: {
+        mockChallengeInfo: process.env["SANBOX_MOCK_CHALLENGE_INFO"] === "true",
+        postMessageToTelegram:
+          process.env["SANDBOX_POST_MESSAGE_TO_TELEGRAM"] === "true",
+        SubmissionIdToFetch:
+          process.env["SANDBOX_SUBMISSION_ID_TO_FETCH"] ??
+          "0xe3432d3a16cfaf59932c3dc809638b8a33a56bf2",
+      },
     },
     infuraConfig: {
       url: (process.env["INFURA_URL"] as string) ?? "",

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -25,7 +25,7 @@ async function main(configuration: AppConfig) {
     telegram.makeMessage(challengeInfoToTelegramMessageData(demoChallengeInfo))
   );
 
-  if (configuration.serverConfig.postMessageToTelegramOnSanbox) {
+  if (configuration.serverConfig.sandboxConfig.postMessageToTelegram) {
     console.info("== Posting message on telegram ==");
     telegram
       .postMessage(configuration.telegramConfig)(
@@ -65,10 +65,14 @@ async function main(configuration: AppConfig) {
   }
 
   async function fetchChallengeInfo(): Promise<Challenge> {
-    console.info("== Get challenge info ==");
-    if (!configuration.serverConfig.mockChallengeInfo) {
+    console.info(
+      "Geting challenge info: " +
+        configuration.serverConfig.sandboxConfig.SubmissionIdToFetch.toLowerCase() +
+        " ..."
+    );
+    if (!configuration.serverConfig.sandboxConfig.mockChallengeInfo) {
       return getChallengeInfo(
-        "0x2ee440fd2b5da461a608843f0ad880496d725857".toLowerCase(),
+        configuration.serverConfig.sandboxConfig.SubmissionIdToFetch.toLowerCase(),
         0,
         0
       );


### PR DESCRIPTION
When the challenge event is called, in some cases there is no
evidence.json on the evidences URI. So in this case a default
reason description is returned