### PR TITLE
Use commit hash on TG GH action plugin version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Send telegram message on pull request to review
         if: github.event.pull_request.merged == false && github.event.action != 'closed'
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@2e9996f96e095a537aa4442da4af41ca7b594fba
         with:
           to: ${{ secrets.TELEGRAM_TO }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
             Title: ${{ github.event.pull_request.title }}
       - name: Send telegram message on pull request merged to main
         if: github.event.pull_request.merged == true
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@2e9996f96e095a537aa4442da4af41ca7b594fba
         with:
           to: ${{ secrets.TELEGRAM_TO }}
           token: ${{ secrets.TELEGRAM_TOKEN }}


### PR DESCRIPTION
In order to approach a less surprises or damages by malware, a commit hash is used instead of the master branch on the `appleboy/telegram-action` Github action.
The commit hashed used in the one associated on the v0.1.1: 2e9996f96e095a537aa4442da4af41ca7b594fba.